### PR TITLE
COMP: Replace NULL by nullptr

### DIFF
--- a/include/IRException.h
+++ b/include/IRException.h
@@ -41,18 +41,18 @@
 class the_exception_t : public std::exception
 {
 public:
-  the_exception_t(const char * description = NULL,
-		  const char * file = NULL,
+  the_exception_t(const char * description = nullptr,
+		  const char * file = nullptr,
 		  const unsigned int & line = 0)
   {
     std::ostringstream os;
     
-    if (file != NULL)
+    if (file != nullptr)
     {
       os << file << ':' << line << " -- ";
     }
     
-    if (description != NULL)
+    if (description != nullptr)
     {
       os << description;
     }

--- a/include/IRFFTCommon.h
+++ b/include/IRFFTCommon.h
@@ -303,8 +303,8 @@ estimate_displacement(the_log_t &                      log,
                       image_t::PointType               offset_max,
                       const double                     overlap_min = 0.0,
                       const double                     overlap_max = 1.0,
-                      const mask_t *                   mask_a = NULL,
-                      const mask_t *                   mask_b = NULL)
+                      const mask_t *                   mask_a = nullptr,
+                      const mask_t *                   mask_b = nullptr)
 {
   // FIXME:
 #ifdef DEBUG_PDF
@@ -427,7 +427,7 @@ match_one_pair(the_log_t &    log,
   DEBUG_COUNTER1++;
 #endif
 
-  ti = NULL;
+  ti = nullptr;
 
   unsigned int total_peaks = 0;
   if (use_std_mask)

--- a/include/IRGridCommon.h
+++ b/include/IRGridCommon.h
@@ -131,8 +131,8 @@ estimate_displacement(the_log_t & log,
                       const local_max_t & lm,
                       const double        overlap_min = 0.05,
                       const double        overlap_max = 1.0,
-                      const mask_t *      mask_a = NULL,
-                      const mask_t *      mask_b = NULL,
+                      const mask_t *      mask_a = nullptr,
+                      const mask_t *      mask_b = nullptr,
 
                       const unsigned int num_perms = 4)
 {
@@ -271,7 +271,7 @@ match_one_pair(the_log_t &                      log,
                const bool &       consider_zero_displacement)
 {
   static const vec2d_t offset = vec2d(0, 0);
-  best_transform = NULL;
+  best_transform = nullptr;
 
   std::list<local_max_t> max_list;
   unsigned int           total_peaks =
@@ -379,7 +379,7 @@ match_one_pair(the_log_t &                      log,
                const unsigned int max_peaks,
                const bool &       consider_zero_displacement)
 {
-  best_transform = NULL;
+  best_transform = nullptr;
 
   std::list<local_max_t> max_list;
   unsigned int           total_peaks =
@@ -845,7 +845,7 @@ extract(const typename TImage::PointType & origin,
     if (interpolator->IsInsideBuffer(tile_pt))
     {
       mask_val = mask_max;
-      if (mask != NULL)
+      if (mask != nullptr)
       {
         mask->TransformPhysicalPointToIndex(tile_pt, mask_ix);
         mask_val = mask->GetPixel(mask_ix);
@@ -1086,7 +1086,7 @@ refine_one_point_helper( // the large images and their masks:
     return false;
   }
 
-  if (img_0_large != NULL)
+  if (img_0_large != nullptr)
   {
     // extract the larger neighborhood from the fixed tile:
     pnt2d_t origin_large(center);
@@ -1283,8 +1283,8 @@ refine_one_point_fft(the_log_t & log,
                                        min_overlap,
                                        sz,
                                        sp,
-                                       NULL,
-                                       NULL,
+                                       nullptr,
+                                       nullptr,
                                        img_0,
                                        msk_0,
                                        img_1,
@@ -1367,7 +1367,7 @@ refine_one_pair(the_log_t & log,
   // setup the masks:
   typedef itk::ImageMaskSpatialObject<2> mask_so_t;
   mask_t::ConstPointer                   fi_mask = m0;
-  if (m0 != NULL)
+  if (m0 != nullptr)
   {
     mask_so_t::Pointer fi_mask_so = mask_so_t::New();
     fi_mask_so->SetImage(fi_mask);
@@ -1375,7 +1375,7 @@ refine_one_pair(the_log_t & log,
   }
 
   mask_t::ConstPointer mi_mask = m1;
-  if (m1 != NULL)
+  if (m1 != nullptr)
   {
     mask_so_t::Pointer mi_mask_so = mask_so_t::New();
     mi_mask_so->SetImage(mi_mask);

--- a/include/IRMosaicRefinementCommon.h
+++ b/include/IRMosaicRefinementCommon.h
@@ -1135,7 +1135,7 @@ refine_mosaic(the_log_t &                                         log,
         log << setw(4) << i << ". warping image tile" << endl;
         warped_tile[i] = warp<image_t>((typename image_t::ConstPointer)tile[i], transform[i].GetPointer());
 
-        if (mask[i].GetPointer() != NULL)
+        if (mask[i].GetPointer() != nullptr)
         {
           log << "      warping image tile mask" << endl;
           warped_mask[i] = warp<mask_t>((typename mask_t::ConstPointer)mask[i], transform[i].GetPointer());
@@ -1243,7 +1243,7 @@ public:
     log_ << setw(4) << tile_index_ << ". warping image tile" << endl;
     warped_tile_[tile_index_] = warp<image_t>(tile_, transform_.GetPointer());
 
-    if (mask_.GetPointer() != NULL)
+    if (mask_.GetPointer() != nullptr)
     {
       log_ << setw(4) << tile_index_ << ". warping image tile mask" << endl;
       warped_mask_[tile_index_] = warp<mask_t>(mask_, transform_.GetPointer());
@@ -1483,7 +1483,7 @@ refine_mosaic_mt(the_log_t &                                         log, // tex
     image_duplicator->Update();
     warped_tile[i] = image_duplicator->GetOutput();
 
-    if (mask[i].GetPointer() != NULL)
+    if (mask[i].GetPointer() != nullptr)
     {
       mask_duplicator->SetInputImage(mask[i]);
       mask_duplicator->Update();

--- a/include/IRStdThreadStorage.h
+++ b/include/IRStdThreadStorage.h
@@ -48,7 +48,7 @@ public:
   // virtual: check whether the thread storage has been initialized:
   bool is_ready() const
   {
-    // return (std::thread_specific_ptr<the_thread_observer_t>::get() != NULL);
+    // return (std::thread_specific_ptr<the_thread_observer_t>::get() != nullptr);
     return true;
   }
   

--- a/include/IRThreadInterface.h
+++ b/include/IRThreadInterface.h
@@ -68,7 +68,7 @@ public:
   
   // the thread will own the mutex passed down to it,
   // it will delete the mutex when the thread is deleted:
-  the_thread_interface_t(the_mutex_interface_t * mutex = NULL);
+  the_thread_interface_t(the_mutex_interface_t * mutex = nullptr);
   
   //----------------------------------------------------------------
   // creator_t

--- a/include/IRThreadPool.h
+++ b/include/IRThreadPool.h
@@ -79,8 +79,8 @@ private:
 struct the_thread_pool_data_t
 {
   the_thread_pool_data_t():
-    parent_(NULL),
-    thread_(NULL),
+    parent_(nullptr),
+    thread_(nullptr),
     id_(~0u)
   {}
   

--- a/include/IRTransaction.h
+++ b/include/IRTransaction.h
@@ -91,7 +91,7 @@ public:
   //----------------------------------------------------------------
   // status_cb_t
   // 
-  // NOTE: if status is NULL, it means the transaction is requesting
+  // NOTE: if status is nullptr, it means the transaction is requesting
   // a callback from the main thread.  This could be used by the
   // transaction for some GUI user interaction (such as finding replacement
   // tiles for a mosaic, etc...)
@@ -110,7 +110,7 @@ public:
   // notify the transaction about a change in it's state:
   virtual void notify(the_transaction_handler_t * handler,
 		      state_t s,
-		      const char * message = NULL);
+		      const char * message = nullptr);
   
   // helper:
   virtual void blab(the_transaction_handler_t * handler,

--- a/include/itkIRCommon.h
+++ b/include/itkIRCommon.h
@@ -685,7 +685,7 @@ pixel_in_mask(const mask_t *                  mask,
       image_size_value_t(mask_index[1]) < mask_size[1])
   {
     // check the mask:
-    return (mask == NULL) ? true : (mask->GetPixel(mask_index) != 0);
+    return (mask == nullptr) ? true : (mask->GetPixel(mask_index) != 0);
   }
 
   // pixel falls outside the mask image:
@@ -701,7 +701,7 @@ template <typename T>
 inline static bool
 pixel_in_mask(const T * mask, const typename T::PointType & physical_point)
 {
-  if (mask == NULL)
+  if (mask == nullptr)
     return true;
 
   typename T::IndexType mask_pixel_index;
@@ -726,7 +726,7 @@ pixel_in_mask(const T *                                            image,
               const itk::Image<unsigned char, T::ImageDimension> * mask,
               const typename T::IndexType &                        image_pixel_index)
 {
-  if (mask == NULL)
+  if (mask == nullptr)
   {
     return true;
   }
@@ -748,7 +748,7 @@ double
 image_min_max(const T *                                            a,
               typename T::PixelType &                              MIN,
               typename T::PixelType &                              MAX,
-              const itk::Image<unsigned char, T::ImageDimension> * mask = NULL)
+              const itk::Image<unsigned char, T::ImageDimension> * mask = nullptr)
 {
   WRAP(itk_terminator_t terminator("image_min_max"));
 
@@ -1222,7 +1222,7 @@ public:
     ValidImages->reserve(num_images);
     for (unsigned int k = 0; k < num_images; k++)
     {
-      if (!(omit[k] || (image[k].GetPointer() == NULL)))
+      if (!(omit[k] || (image[k].GetPointer() == nullptr)))
       {
         ValidImages->push_back(image[k]);
       }
@@ -1579,7 +1579,7 @@ load(const char * filename, bool blab = true)
   {
     cout << "Exception loading " << filename << endl;
     cout << e.GetDescription() << endl;
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -1908,8 +1908,8 @@ double
 eval_metric(const base_transform_t *                   fi_to_mi,
             const typename metric_t::FixedImageType *  fi,
             const typename metric_t::MovingImageType * mi,
-            const mask_t *                             fi_mask = NULL,
-            const mask_t *                             mi_mask = NULL)
+            const mask_t *                             fi_mask = nullptr,
+            const mask_t *                             mi_mask = nullptr)
 {
   typename metric_t::Pointer metric = metric_t::New();
   metric->SetFixedImage(fi);
@@ -1953,12 +1953,12 @@ eval_metric(const base_transform_t *                   fi_to_mi,
 
   metric->SetFixedImageRegion(fi_roi);
 
-  if (fi_mask != NULL)
+  if (fi_mask != nullptr)
   {
     metric->SetFixedImageMask(mask_so(fi_mask));
   }
 
-  if (mi_mask != NULL)
+  if (mi_mask != nullptr)
   {
     metric->SetMovingImageMask(mask_so(mi_mask));
   }
@@ -2503,8 +2503,8 @@ my_metric(double &                 overlap,
           const TImage *           fi,
           const TImage *           mi,
           const base_transform_t * fi_to_mi,
-          const mask_t *           fi_mask = NULL,
-          const mask_t *           mi_mask = NULL,
+          const mask_t *           fi_mask = nullptr,
+          const mask_t *           mi_mask = nullptr,
           const double             min_overlap = 0.05,
           const double             max_overlap = 1.0)
 {
@@ -2559,8 +2559,8 @@ double
 my_metric(const TImage *           fi,
           const TImage *           mi,
           const base_transform_t * fi_to_mi,
-          const mask_t *           fi_mask = NULL,
-          const mask_t *           mi_mask = NULL,
+          const mask_t *           fi_mask = nullptr,
+          const mask_t *           mi_mask = nullptr,
           const double             min_overlap = 0.0,
           const double             max_overlap = 1.0)
 {
@@ -2599,7 +2599,7 @@ calc_image_bboxes(const std::vector<typename IMG::ConstPointer> & image,
     image_max[i][1] = -image_min[i][0];
 
     // it happens:
-    if (image[i].GetPointer() == NULL)
+    if (image[i].GetPointer() == nullptr)
       continue;
 
     // bounding box in the image space:
@@ -2662,7 +2662,7 @@ calc_image_bboxes_load_images(const std::list<the_text_t> & in,
     calc_image_bbox<IMG>(image, image_min[i], image_max[i]);
 
     // Unload the image.
-    image = typename IMG::Pointer(NULL);
+    image = typename IMG::Pointer(nullptr);
   }
 }
 
@@ -2924,7 +2924,7 @@ typedef enum
 // Each tile may be individually tinted with a grayscale color.
 // Individual tiles may be omitted.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 template <class IMG, class transform_t, class img_interpolator_t>
 typename IMG::Pointer
@@ -2976,11 +2976,11 @@ make_mosaic_st(
   // setup the image mask interpolators:
   typedef itk::NearestNeighborInterpolateImageFunction<mask_t, double> msk_interpolator_t;
   std::vector<typename msk_interpolator_t::Pointer>                    msk(num_images);
-  msk.assign(num_images, typename msk_interpolator_t::Pointer(NULL));
+  msk.assign(num_images, typename msk_interpolator_t::Pointer(nullptr));
 
   for (unsigned int i = 0; i < image_mask.size() && i < num_images; i++)
   {
-    if (image_mask[i].GetPointer() == NULL)
+    if (image_mask[i].GetPointer() == nullptr)
       continue;
 
     msk[i] = msk_interpolator_t::New();
@@ -3004,7 +3004,7 @@ make_mosaic_st(
   mosaic->SetRegions(mosaic_sz);
   mosaic->SetSpacing(mosaic_sp);
 
-  mosaic_mask = NULL;
+  mosaic_mask = nullptr;
   if (assemble_mosaic_mask)
   {
     mosaic_mask = mask_t::New();
@@ -3037,7 +3037,7 @@ make_mosaic_st(
   ValidTilesIndicies.reserve(num_images);
   for (unsigned int k = 0; k < num_images; k++)
   {
-    InvalidTiles[k] = (omit[k] || (image[k].GetPointer() == NULL));
+    InvalidTiles[k] = (omit[k] || (image[k].GetPointer() == nullptr));
     if (!InvalidTiles[k])
     {
       ValidTilesIndicies.push_back(k);
@@ -3090,7 +3090,7 @@ make_mosaic_st(
 
 
         // don't try to add missing or omitted images to the mosaic:
-        //      if (omit[k] || (image[k].GetPointer() == NULL)) continue;
+        //      if (omit[k] || (image[k].GetPointer() == nullptr)) continue;
 
         // avoid undesirable distortion artifacts:
         if (!inside_bbox(MIN[k], MAX[k], point))
@@ -3106,7 +3106,7 @@ make_mosaic_st(
 
         // make sure the pixel maps into the image mask:
         pixel_t alpha = 1.0;
-        if ((msk[k].GetPointer() != NULL) && (alpha = msk[k]->Evaluate(pt_k)) < 1.0)
+        if ((msk[k].GetPointer() != nullptr) && (alpha = msk[k]->Evaluate(pt_k)) < 1.0)
           continue;
 
         // feather out the edges by giving them a tiny weight:
@@ -3260,7 +3260,7 @@ public:
     {
       unsigned int j = SortedTiles[k];
 
-      if (tile[k].GetPointer() == NULL)
+      if (tile[k].GetPointer() == nullptr)
       {
         continue;
       }
@@ -3376,7 +3376,7 @@ public:
 
           // make sure the pixel maps into the image mask:
           pxl_t alpha = 1.0;
-          if ((imask_[k].GetPointer() != NULL) && (alpha = imask_[k]->Evaluate(pt_k)) < 1.0)
+          if ((imask_[k].GetPointer() != nullptr) && (alpha = imask_[k]->Evaluate(pt_k)) < 1.0)
           {
             continue;
           }
@@ -3504,7 +3504,7 @@ public:
 // Each tile may be individually tinted with a grayscale color.
 // Individual tiles may be omitted.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 template <class IMG, class transform_t, class img_interpolator_t>
 typename IMG::Pointer
@@ -3569,11 +3569,11 @@ make_mosaic_mt(
   // setup the image mask interpolators:
   typedef itk::NearestNeighborInterpolateImageFunction<mask_t, double> msk_interpolator_t;
   std::vector<typename msk_interpolator_t::Pointer>                    msk(num_images);
-  msk.assign(num_images, typename msk_interpolator_t::Pointer(NULL));
+  msk.assign(num_images, typename msk_interpolator_t::Pointer(nullptr));
 
   for (unsigned int i = 0; i < image_mask.size() && i < num_images; i++)
   {
-    if (image_mask[i].GetPointer() == NULL)
+    if (image_mask[i].GetPointer() == nullptr)
       continue;
 
     msk[i] = msk_interpolator_t::New();
@@ -3596,7 +3596,7 @@ make_mosaic_mt(
   mosaic->SetRegions(mosaic_sz);
   mosaic->SetSpacing(mosaic_sp);
 
-  mosaic_mask = NULL;
+  mosaic_mask = nullptr;
   if (assemble_mosaic_mask)
   {
     mosaic_mask = mask_t::New();
@@ -3671,7 +3671,7 @@ make_mosaic_mt(
 // Each tile may be individually tinted with a grayscale color.
 // Individual tiles may be omitted.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 // Use all possible processors/cores available for multi-threading:
 //
@@ -3969,7 +3969,7 @@ class save_mosaic
 
   save_mosaic()
   {
-    if (_pthread_pool == NULL)
+    if (_pthread_pool == nullptr)
     {
       _pthread_pool = new the_thread_pool_t(NUM_THREADS_FOR_ASYNC_SAVE);
       _pthread_pool->set_idle_sleep_duration(50); // 50 usec
@@ -3979,10 +3979,10 @@ class save_mosaic
 
   ~save_mosaic()
   {
-    if (_pthread_pool != NULL)
+    if (_pthread_pool != nullptr)
     {
       delete _pthread_pool;
-      _pthread_pool = NULL;
+      _pthread_pool = nullptr;
     }
   }
 
@@ -3995,7 +3995,7 @@ public:
         bool                     blab = true)
   {
     typename T::ConstPointer pT = image;
-    if (_pthread_pool == NULL)
+    if (_pthread_pool == nullptr)
     {
       _pthread_pool = new the_thread_pool_t(NUM_THREADS_FOR_ASYNC_SAVE);
       _pthread_pool->set_idle_sleep_duration(50); // 50 usec
@@ -4042,14 +4042,14 @@ public:
   static void
   WaitForAsync()
   {
-    if (_pthread_pool == NULL)
+    if (_pthread_pool == nullptr)
     {
       return;
     }
     else
     {
       _pthread_pool->wait();
-      _pthread_pool = NULL;
+      _pthread_pool = nullptr;
     }
   }
 };
@@ -4111,7 +4111,7 @@ public:
     // feathering to reduce image blurring is optional:
     const feathering_t      feathering = FEATHER_NONE_E,
     typename IMG::PixelType background = 255.0,
-    OUTPUT *                output = NULL,
+    OUTPUT *                output = nullptr,
     the_text_t              saveFileName = "")
     : // If we should save the image to disk, use this filename
     m_num_threads(num_threads)
@@ -4130,7 +4130,7 @@ public:
     , m_pOutput(output)
   {
     m_SaveFileName = saveFileName.text();
-    if (m_pOutput != NULL)
+    if (m_pOutput != nullptr)
     {
       m_pOutput->SaveFileName = saveFileName.text();
     }
@@ -4178,7 +4178,7 @@ public:
     }
 
 
-    if (m_pOutput != NULL)
+    if (m_pOutput != nullptr)
     {
       m_pOutput->mosaic = mosaic;
 
@@ -4208,8 +4208,8 @@ typename T::Pointer
 update_mosaic(const T *                mosaic,
               const T *                tile,
               const base_transform_t * tile_transform,
-              const mask_t *           mask_mosaic = NULL,
-              const mask_t *           mask_tile = NULL)
+              const mask_t *           mask_mosaic = nullptr,
+              const mask_t *           mask_tile = nullptr)
 {
   std::vector<typename T::ConstPointer> image(2);
   image[0] = mosaic;
@@ -4256,11 +4256,11 @@ make_mask_st(const mask_t::SpacingType &                             mosaic_sp,
   // setup the image mask interpolators:
   typedef itk::NearestNeighborInterpolateImageFunction<mask_t, double> msk_interpolator_t;
   std::vector<typename msk_interpolator_t::Pointer>                    msk(num_images);
-  msk.assign(num_images, typename msk_interpolator_t::Pointer(NULL));
+  msk.assign(num_images, typename msk_interpolator_t::Pointer(nullptr));
 
   for (unsigned int i = 0; i < image_mask.size() && i < num_images; i++)
   {
-    if (image_mask[i].GetPointer() == NULL)
+    if (image_mask[i].GetPointer() == nullptr)
       continue;
 
     msk[i] = msk_interpolator_t::New();
@@ -4310,7 +4310,7 @@ make_mask_st(const mask_t::SpacingType &                             mosaic_sp,
     for (unsigned int k = 0; k < num_images; k++)
     {
       // don't try to add missing or omitted images to the mosaic:
-      if (omit[k] || (image_mask[k].GetPointer() == NULL))
+      if (omit[k] || (image_mask[k].GetPointer() == nullptr))
         continue;
 
       // avoid undesirable radial distortion artifacts for R >> Rmax:
@@ -4549,11 +4549,11 @@ make_mask_mt(unsigned int                                            num_threads
   // setup the image mask interpolators:
   typedef itk::NearestNeighborInterpolateImageFunction<mask_t, double> imask_t;
   std::vector<typename imask_t::Pointer>                               imask(num_images);
-  imask.assign(num_images, typename imask_t::Pointer(NULL));
+  imask.assign(num_images, typename imask_t::Pointer(nullptr));
 
   for (unsigned int i = 0; i < image_mask.size() && i < num_images; i++)
   {
-    if (image_mask[i].GetPointer() == NULL)
+    if (image_mask[i].GetPointer() == nullptr)
       continue;
 
     imask[i] = imask_t::New();
@@ -4822,7 +4822,7 @@ save_composite(const char * filename, const T * fi, const T * mi, const base_tra
 // Each tile may be individually tinted with an RGB color.
 // Individual tiles may be omitted.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 template <class IMG, class transform_t>
 void
@@ -4877,7 +4877,7 @@ make_mosaic_rgb(typename IMG::Pointer *                                 mosaic,
 // Each tile may be individually tinted with an RGB color.
 // Individual tiles may be omitted.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 template <class IMG, class transform_t>
 void
@@ -4912,7 +4912,7 @@ make_mosaic_rgb(typename IMG::Pointer *                                 mosaic,
 // Each tile may be individually tinted with an RGB color.
 // Individual tiles may be omitted.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 template <class IMG, class transform_t>
 void
@@ -4957,7 +4957,7 @@ make_colors(const unsigned int & num_color, std::vector<xyz_t> & color);
 // from a scrambled rainbox colormap.
 // Individual tiles may be omitted.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 template <class IMG, class transform_t>
 void
@@ -5013,7 +5013,7 @@ make_mosaic_rgb(typename IMG::Pointer *                                 mosaic,
 // Each tile will be tinted with an RGB color
 // from a scrambled rainbox colormap.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 template <class IMG, class transform_t>
 void
@@ -5087,7 +5087,7 @@ save_rgb(const image_ptr_t * image, const char * filename, bool blab = true)
 // Each tile will be tinted with an RGB color
 // from a scrambled rainbox colormap.
 // Background color (outside the mask) may be specified.
-// Tile masks are optional and may be NULL.
+// Tile masks are optional and may be nullptr.
 //
 // Save the resulting mosaic
 //
@@ -5499,7 +5499,7 @@ histogram_equalization(const T *             in,
                        const unsigned int    bins = 256,
                        typename T::PixelType new_min = std::numeric_limits<typename T::PixelType>::max(),
                        typename T::PixelType new_max = -std::numeric_limits<typename T::PixelType>::max(),
-                       const mask_t *        mask = NULL)
+                       const mask_t *        mask = nullptr)
 {
   // local typedefs:
   typedef typename T::RegionType rn_t;
@@ -5612,7 +5612,7 @@ CLAHE(const T *             in,
       const unsigned int    bins = 256,
       typename T::PixelType new_min = std::numeric_limits<typename T::PixelType>::max(),
       typename T::PixelType new_max = -std::numeric_limits<typename T::PixelType>::max(),
-      const mask_t *        mask = NULL)
+      const mask_t *        mask = nullptr)
 {
   // local typedefs:
   typedef typename T::RegionType rn_t;
@@ -5932,7 +5932,7 @@ normalize(const T *             image,
           const unsigned int    rows,
           typename T::PixelType new_min = std::numeric_limits<typename T::PixelType>::max(),
           typename T::PixelType new_max = -std::numeric_limits<typename T::PixelType>::max(),
-          const mask_t *        mask = NULL)
+          const mask_t *        mask = nullptr)
 {
   WRAP(itk_terminator_t terminator("normalize"));
 
@@ -6141,7 +6141,7 @@ template <typename T>
 double
 overlap_ratio(const T * fi, const T * mi, const base_transform_t * fi_to_mi)
 {
-  if (fi_to_mi == NULL)
+  if (fi_to_mi == nullptr)
     return 0.0;
 
   typename T::PointType fi_min = fi->GetOrigin();
@@ -6466,7 +6466,7 @@ solve_for_transform(const T *                                tile,
 {
   base_transform_t::Pointer tile_to_mosaic;
   mosaic_to_tile_0->GetInverse(tile_to_mosaic);
-  assert(tile_to_mosaic.GetPointer() != NULL);
+  assert(tile_to_mosaic.GetPointer() != nullptr);
 
   typename T::SizeType    sz = tile->GetLargestPossibleRegion().GetSize();
   typename T::SpacingType sp = tile->GetSpacing();
@@ -6685,7 +6685,7 @@ load_volume_slice(std::istream &                  si,
 
       itk::TransformBase::Pointer t_base = load_transform(si);
       transform = dynamic_cast<transform_t *>(t_base.GetPointer());
-      assert(transform.GetPointer() != NULL);
+      assert(transform.GetPointer() != nullptr);
     }
     else
     {

--- a/include/itkIRDynamicArray.h
+++ b/include/itkIRDynamicArray.h
@@ -78,14 +78,14 @@ class the_dynamic_array_t
 {
 public:
   the_dynamic_array_t():
-    array_(NULL),
+    array_(nullptr),
     page_size_(16),
     size_(0),
     init_value_()
   {}
   
   the_dynamic_array_t(const size_t & init_size):
-    array_(NULL),
+    array_(nullptr),
     page_size_(init_size),
     size_(0),
     init_value_()
@@ -94,7 +94,7 @@ public:
   the_dynamic_array_t(const size_t & init_size,
 		      const size_t & page_size,
 		      const T & init_value):
-    array_(NULL),
+    array_(nullptr),
     page_size_(page_size),
     size_(0),
     init_value_(init_value)
@@ -104,7 +104,7 @@ public:
   
   // copy constructor:
   the_dynamic_array_t(const the_dynamic_array_t<T> & a):
-    array_(NULL),
+    array_(nullptr),
     page_size_(0),
     size_(0),
     init_value_(a.init_value_)
@@ -128,7 +128,7 @@ public:
     }
     
     delete array_;
-    array_ = NULL;
+    array_ = nullptr;
     
     size_ = 0;
   }
@@ -205,7 +205,7 @@ public:
   
   // number of pages currently allocated:
   inline size_t num_pages() const
-  { return (array_ == NULL) ? 0 : array_->size(); }
+  { return (array_ == nullptr) ? 0 : array_->size(); }
   
   inline const T * page(const size_t & page_index) const
   { return &((*(*array_)[page_index])[0]); }

--- a/include/itkIRText.h
+++ b/include/itkIRText.h
@@ -68,7 +68,7 @@ public:
   inline void clear()
   {
     delete [] text_;
-    text_ = NULL;
+    text_ = nullptr;
     size_ = 0;
   }
   
@@ -192,16 +192,16 @@ public:
   }
   
   short int                toShort(bool * ok = 0, int base = 10) const;
-  unsigned short int        toUShort(bool * ok = NULL, int base = 10) const;
+  unsigned short int        toUShort(bool * ok = nullptr, int base = 10) const;
   
-  int                        toInt(bool * ok = NULL, int base = 10) const;
-  unsigned int                toUInt(bool * ok = NULL, int base = 10) const;
+  int                        toInt(bool * ok = nullptr, int base = 10) const;
+  unsigned int                toUInt(bool * ok = nullptr, int base = 10) const;
   
-  long int                toLong(bool * ok = NULL, int base = 10) const;
-  unsigned long int        toULong(bool * ok = NULL, int base = 10) const;
+  long int                toLong(bool * ok = nullptr, int base = 10) const;
+  unsigned long int        toULong(bool * ok = nullptr, int base = 10) const;
   
-  float                        toFloat(bool * ok = NULL) const;
-  double                toDouble(bool * ok = NULL) const;
+  float                        toFloat(bool * ok = nullptr) const;
+  double                toDouble(bool * ok = nullptr) const;
 
   void to_ascii();
   void to_lower();

--- a/include/itkIRUtils.h
+++ b/include/itkIRUtils.h
@@ -745,7 +745,7 @@ public:
   
   inline void arm()
   {
-    if (!armed_ && lock_ != NULL)
+    if (!armed_ && lock_ != nullptr)
     {
       lock_->lock();
       armed_ = true;
@@ -754,7 +754,7 @@ public:
   
   inline void disarm()
   {
-    if (armed_ && lock_ != NULL)
+    if (armed_ && lock_ != nullptr)
     {
       lock_->unlock();
       armed_ = false;
@@ -780,7 +780,7 @@ public:
   the_unlock_t(T * lock):
     lock_(lock)
   {
-    if (lock_ != NULL)
+    if (lock_ != nullptr)
     {
       assert(lock_->try_lock() == false);
     }
@@ -789,7 +789,7 @@ public:
   the_unlock_t(T & lock):
     lock_(&lock)
   {
-    if (lock_ != NULL)
+    if (lock_ != nullptr)
     {
       assert(lock_->try_lock() == false);
     }
@@ -797,7 +797,7 @@ public:
   
   ~the_unlock_t()
   {
-    if (lock_ != NULL)
+    if (lock_ != nullptr)
     {
       lock_->unlock();
     }

--- a/include/itkInverseTransform.h
+++ b/include/itkInverseTransform.h
@@ -100,7 +100,7 @@ namespace itk
     /**  Method to transform a point. */
     virtual OutputPointType TransformPoint(const InputPointType & y) const
     {
-      assert(forward_ != NULL);
+      assert(forward_ != nullptr);
       return forward_->BackTransformPoint(y);
     }
     

--- a/src/IRFFT.cxx
+++ b/src/IRFFT.cxx
@@ -54,14 +54,14 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 namespace itk_fft
 {
-	// static the_mutex_interface_t * mutex = NULL; 
+	// static the_mutex_interface_t * mutex = nullptr; 
 	// //----------------------------------------------------------------
 	// // fftw_mutex
 	// // 
 	// static the_mutex_interface_t *
 	// 	fftw_mutex()
 	// {
-	// 	if(mutex == NULL)
+	// 	if(mutex == nullptr)
 	// 		mutex = the_mutex_interface_t::create();
 	// 	return mutex;
 	// }
@@ -96,13 +96,13 @@ namespace itk_fft
 	// {
 	// public:
 	// 	fft_cache_t():
-	// 	  fwd_(NULL),
-	// 		  inv_(NULL),
+	// 	  fwd_(nullptr),
+	// 		  inv_(nullptr),
 	// 		  w_(0),
 	// 		  h_(0),
 	// 		  h_complex_(0),
 	// 		  h_padded_(0),
-	// 		  buffer_(NULL)
+	// 		  buffer_(nullptr)
 	// 	  {}
 
 	// 	  ~fft_cache_t()
@@ -118,13 +118,13 @@ namespace itk_fft
 	// 			//   the_lock_t<the_mutex_interface_t> lock(fftw_mutex());
 
 	// 			  fftwf_destroy_plan(fwd_);
-	// 			  fwd_ = NULL;
+	// 			  fwd_ = nullptr;
 
 	// 			  fftwf_destroy_plan(inv_);
-	// 			  inv_ = NULL;
+	// 			  inv_ = nullptr;
 
 	// 			  fftwf_free(buffer_);
-	// 			  buffer_ = NULL;
+	// 			  buffer_ = nullptr;
 	// 		  }
 
 	// 		  w_ = 0;
@@ -269,8 +269,8 @@ namespace itk_fft
 	void
 		fft_data_t::cleanup()
 	{
-		// if (data_ != NULL) fftwf_free((fft_complex_t *)(data_));
-		// data_ = NULL;
+		// if (data_ != nullptr) fftwf_free((fft_complex_t *)(data_));
+		// data_ = nullptr;
 		nx_ = 0;
 		ny_ = 0;
 	}
@@ -285,9 +285,9 @@ namespace itk_fft
 		const unsigned int old_sz = nx_ * ny_;
 		if (old_sz == new_sz) return;
 
-		// if (data_ != NULL) fftwf_free((fft_complex_t *)(data_));
+		// if (data_ != nullptr) fftwf_free((fft_complex_t *)(data_));
 		// data_ = (fft_complex_t *)(fftwf_malloc(new_sz * sizeof(fft_complex_t)));
-		// assert(data_ != NULL);
+		// assert(data_ != nullptr);
 		image_->SetRegions({ w, h });
 		image_->Allocate();
 

--- a/src/IRGridCommon.cxx
+++ b/src/IRGridCommon.cxx
@@ -59,7 +59,7 @@ setup_grid_transform(the_grid_transform_t &         transform,
   // the mosaic to tile transform is typically more stable:
   approx_transform_t::Pointer mosaic_to_tile_approx;
 
-  if (gt == NULL)
+  if (gt == nullptr)
   {
     mosaic_to_tile_approx = approx_transform<approx_transform_t>(tile_min,
                                                                  tile_max,
@@ -93,7 +93,7 @@ setup_grid_transform(the_grid_transform_t &         transform,
       pnt2d_t &    xy = xy_arr[index];
       pnt2d_t &    xy_approx = xy_apx[index];
 
-      if (gt == NULL)
+      if (gt == nullptr)
       {
         // general transform:
         if (!find_inverse(tile_min,
@@ -212,7 +212,7 @@ setup_mesh_transform(the_mesh_transform_t &         transform,
   // the mosaic to tile transform is typically more stable:
   approx_transform_t::Pointer mosaic_to_tile_approx;
 
-  if (gt == NULL)
+  if (gt == nullptr)
   {
     mosaic_to_tile_approx = approx_transform<approx_transform_t>(tile_min,
                                                                  tile_max,
@@ -245,7 +245,7 @@ setup_mesh_transform(the_mesh_transform_t &         transform,
       pnt2d_t &    xy_approx = xy_apx[index];
       uv_list[index] = pq;
 
-      if (gt == NULL)
+      if (gt == nullptr)
       {
         // general transform:
         if (!find_inverse(tile_min,

--- a/src/IRLog.cxx
+++ b/src/IRLog.cxx
@@ -34,7 +34,7 @@
 // the_log_t::the_log_t
 // 
 the_log_t::the_log_t():
-  mutex_(NULL)
+  mutex_(nullptr)
 {
   mutex_ = the_mutex_interface_t::create();
 }
@@ -158,8 +158,8 @@ the_log_t::copyfmt(std::ostream & ostm)
 the_null_log_t *
 null_log()
 {
-  static the_null_log_t * log = NULL;
-  if (log == NULL)
+  static the_null_log_t * log = nullptr;
+  if (log == nullptr)
   {
     log = new the_null_log_t;
   }
@@ -174,8 +174,8 @@ null_log()
 the_stream_log_t *
 cerr_log()
 {
-  static the_stream_log_t * log = NULL;
-  if (log == NULL)
+  static the_stream_log_t * log = nullptr;
+  if (log == nullptr)
   {
     log = new the_stream_log_t(std::cerr);
   }
@@ -190,8 +190,8 @@ cerr_log()
 the_stream_log_t *
 cout_log()
 {
-  static the_stream_log_t * log = NULL;
-  if (log == NULL)
+  static the_stream_log_t * log = nullptr;
+  if (log == nullptr)
   {
     log = new the_stream_log_t(std::cout);
   }

--- a/src/IRMutexInterface.cxx
+++ b/src/IRMutexInterface.cxx
@@ -37,7 +37,7 @@
 // the_mutex_interface_t::creator_
 // 
 the_mutex_interface_t::creator_t
-the_mutex_interface_t::creator_ = NULL;
+the_mutex_interface_t::creator_ = nullptr;
 
 //----------------------------------------------------------------
 // the_mutex_interface_t::~the_mutex_interface_t
@@ -60,6 +60,6 @@ the_mutex_interface_t::set_creator(the_mutex_interface_t::creator_t creator)
 the_mutex_interface_t *
 the_mutex_interface_t::create()
 {
-  if (creator_ == NULL) return NULL;
+  if (creator_ == nullptr) return nullptr;
   return creator_();
 }

--- a/src/IRStdThread.cxx
+++ b/src/IRStdThread.cxx
@@ -56,7 +56,7 @@ static thread_local the_std_thread_storage_t THREAD_STORAGE;
 // 
 the_std_thread_t::the_std_thread_t():
   the_thread_interface_t(the_std_mutex_t::create()),
-  std_thread_(NULL)
+  std_thread_(nullptr)
 {
   if (THREAD_STORAGE.thread_observer_.get() == nullptr)
   {
@@ -152,7 +152,7 @@ the_std_thread_t::wait()
   
   std_thread_->join();
   delete std_thread_;
-  std_thread_ = NULL;
+  std_thread_ = nullptr;
 }
 
 //----------------------------------------------------------------

--- a/src/IRThreadInterface.cxx
+++ b/src/IRThreadInterface.cxx
@@ -53,8 +53,8 @@ using std::endl;
 // 
 static the_mutex_interface_t * MUTEX()
 {
-  static the_mutex_interface_t * mutex_ = NULL;
-  if (mutex_ == NULL)
+  static the_mutex_interface_t * mutex_ = nullptr;
+  if (mutex_ == nullptr)
   {
     mutex_ = the_mutex_interface_t::create();
   }
@@ -67,7 +67,7 @@ static the_mutex_interface_t * MUTEX()
 // the_thread_interface_t::creator_
 // 
 the_thread_interface_t::creator_t
-the_thread_interface_t::creator_ = NULL;
+the_thread_interface_t::creator_ = nullptr;
 
 //----------------------------------------------------------------
 // the_thread_interface_t::the_thread_interface_t
@@ -77,9 +77,9 @@ the_thread_interface_t::the_thread_interface_t(the_mutex_interface_t * mutex):
   stopped_(true),
   sleep_when_idle_(false),
   sleep_microsec_(10000),
-  active_transaction_(NULL),
-  thread_pool_(NULL),
-  thread_pool_cb_data_(NULL)
+  active_transaction_(nullptr),
+  thread_pool_(nullptr),
+  thread_pool_cb_data_(nullptr)
 {
   the_lock_t<the_mutex_interface_t> locker(MUTEX());
   static unsigned int counter = 0;
@@ -109,7 +109,7 @@ the_thread_interface_t::set_creator(the_thread_interface_t::creator_t creator)
 the_thread_interface_t *
 the_thread_interface_t::create()
 {
-  if (creator_ == NULL) return NULL;
+  if (creator_ == nullptr) return nullptr;
   return creator_();
 }
 
@@ -170,7 +170,7 @@ the_thread_interface_t::push_back(std::list<the_transaction_t *> & schedule)
 bool
 the_thread_interface_t::has_work() const
 {
-  return (active_transaction_ != NULL) || !transactions_.empty();
+  return (active_transaction_ != nullptr) || !transactions_.empty();
 }
 
 //----------------------------------------------------------------
@@ -353,19 +353,19 @@ the_thread_interface_t::work()
 {
   the_lock_t<the_mutex_interface_t> lock_this(mutex_, false);
   the_lock_t<the_mutex_interface_t> lock_pool(thread_pool_ ?
-					      thread_pool_->mutex_ : NULL,
+					      thread_pool_->mutex_ : nullptr,
 					      false);
   bool all_transactions_completed = true;
   
   while (!stopped_)
   {
     // get the next transaction:
-    the_transaction_t * t = NULL;
+    the_transaction_t * t = nullptr;
     {
       lock_pool.arm();
       lock_this.arm();
       
-      if (thread_pool_ != NULL)
+      if (thread_pool_ != nullptr)
       {
 	// call back the thread pool:
 #ifdef DEBUG_THREAD
@@ -412,12 +412,12 @@ the_thread_interface_t::work()
       t->notify(this, the_transaction_t::STARTED_E);
       t->execute(this);
       all_transactions_completed = (all_transactions_completed && true);
-      active_transaction_ = NULL;
+      active_transaction_ = nullptr;
       t->notify(this, the_transaction_t::DONE_E);
     }
     catch (std::exception & e)
     {
-      active_transaction_ = NULL;
+      active_transaction_ = nullptr;
 #ifdef DEBUG_THREAD
       cerr << "FIXME: caught exception: " << e.what() << endl;
 #endif
@@ -427,7 +427,7 @@ the_thread_interface_t::work()
     }
     catch (...)
     {
-      active_transaction_ = NULL;
+      active_transaction_ = nullptr;
 #ifdef DEBUG_THREAD
       cerr << "FIXME: caught unknonwn exception" << endl;
 #endif
@@ -462,7 +462,7 @@ the_thread_interface_t::work()
   cerr << "thread " << this << " is finished" << endl;
 #endif
   
-  if (thread_pool_ != NULL)
+  if (thread_pool_ != nullptr)
   {
     lock_pool.arm();
     lock_this.arm();
@@ -498,7 +498,7 @@ the_thread_interface_t::handle(the_transaction_t * transaction,
 void
 the_thread_interface_t::blab(const char * message) const
 {
-  if (thread_pool_ == NULL)
+  if (thread_pool_ == nullptr)
   {
     cerr << message << endl;
   }

--- a/src/IRThreadPool.cxx
+++ b/src/IRThreadPool.cxx
@@ -57,7 +57,7 @@ the_transaction_wrapper_t(const unsigned int & num_parts,
   cb_data_(transaction->notify_cb_data_),
   num_parts_(num_parts)
 {
-  assert(mutex_ != NULL);
+  assert(mutex_ != nullptr);
   
   for (unsigned int i = 0; i <= the_transaction_t::DONE_E; i++)
   {
@@ -72,7 +72,7 @@ the_transaction_wrapper_t(const unsigned int & num_parts,
 the_transaction_wrapper_t::~the_transaction_wrapper_t()
 {
   mutex_->delete_this();
-  mutex_ = NULL;
+  mutex_ = nullptr;
 }
 
 //----------------------------------------------------------------
@@ -110,7 +110,7 @@ the_transaction_wrapper_t::notify(the_transaction_t * t,
   {
     case the_transaction_t::PENDING_E:
     case the_transaction_t::STARTED_E:
-      if (notified_[s] == 1 && num_terminal_notifications == 0 && cb_ != NULL)
+      if (notified_[s] == 1 && num_terminal_notifications == 0 && cb_ != nullptr)
       {
 	cb_(cb_data_, t, s);
       }
@@ -136,7 +136,7 @@ the_transaction_wrapper_t::notify(the_transaction_t * t,
 	    t->set_state(state);
 	  }
 	  
-	  if (cb_ != NULL)
+	  if (cb_ != nullptr)
 	  {
 	    cb_(cb_data_, t, t->state());
 	  }
@@ -165,7 +165,7 @@ the_thread_pool_t::the_thread_pool_t(unsigned int num_threads):
   pool_size_(num_threads)
 {
   mutex_ = the_mutex_interface_t::create();
-  assert(mutex_ != NULL);
+  assert(mutex_ != nullptr);
   
   pool_ = new the_thread_pool_data_t[num_threads];
   for (unsigned int i = 0; i < num_threads; i++)
@@ -173,7 +173,7 @@ the_thread_pool_t::the_thread_pool_t(unsigned int num_threads):
     pool_[i].id_ = i;
     pool_[i].parent_ = this;
     pool_[i].thread_ = the_thread_interface_t::create();
-    assert(pool_[i].thread_ != NULL);
+    assert(pool_[i].thread_ != nullptr);
     pool_[i].thread_->set_thread_pool_cb(this, &pool_[i]);
     
     // mark the thread as idle, initially:
@@ -187,10 +187,10 @@ the_thread_pool_t::the_thread_pool_t(unsigned int num_threads):
 the_thread_pool_t::~the_thread_pool_t()
 {
   mutex_->delete_this();
-  mutex_ = NULL;
+  mutex_ = nullptr;
   
   delete [] pool_;
-  pool_ = NULL;
+  pool_ = nullptr;
   pool_size_ = 0;
 }
 
@@ -307,13 +307,13 @@ wrap(the_transaction_t * transaction,
      the_thread_pool_t * pool,
      bool multithreaded)
 {
-  if (transaction->notify_cb() == NULL)
+  if (transaction->notify_cb() == nullptr)
   {
     // override the callback:
     transaction->set_notify_cb(::notify_cb, pool);
   }
   
-  if (transaction->status_cb() == NULL)
+  if (transaction->status_cb() == nullptr)
   {
     // override the callback:
     transaction->set_status_cb(::status_cb, pool);

--- a/src/IRTransaction.cxx
+++ b/src/IRTransaction.cxx
@@ -43,10 +43,10 @@ the_transaction_t::the_transaction_t():
   mutex_(the_mutex_interface_t::create()),
   request_(NOTHING_E),
   state_(PENDING_E),
-  notify_cb_(NULL),
-  notify_cb_data_(NULL),
-  status_cb_(NULL),
-  status_cb_data_(NULL)
+  notify_cb_(nullptr),
+  notify_cb_data_(nullptr),
+  status_cb_(nullptr),
+  status_cb_data_(nullptr)
 {}
 
 //----------------------------------------------------------------
@@ -54,10 +54,10 @@ the_transaction_t::the_transaction_t():
 // 
 the_transaction_t::~the_transaction_t()
 {
-  if (mutex_ != NULL)
+  if (mutex_ != nullptr)
   {
     mutex_->delete_this();
-    mutex_ = NULL;
+    mutex_ = nullptr;
   }
 }
 
@@ -72,7 +72,7 @@ the_transaction_t::notify(the_transaction_handler_t * handler,
   set_state(s);
   blab(handler, message);
   
-  if (notify_cb_ == NULL)
+  if (notify_cb_ == nullptr)
   {
     handler->handle(this, s);
   }
@@ -89,9 +89,9 @@ void
 the_transaction_t::blab(the_transaction_handler_t * handler,
 			const char * message)
 {
-  if (message == NULL) return;
+  if (message == nullptr) return;
   
-  if (status_cb_ == NULL)
+  if (status_cb_ == nullptr)
   {
     handler->blab(message);
   }
@@ -107,7 +107,7 @@ the_transaction_t::blab(the_transaction_handler_t * handler,
 bool
 the_transaction_t::callback_request()
 {
-  if (status_cb_ == NULL)
+  if (status_cb_ == nullptr)
   {
     return false;
   }
@@ -119,7 +119,7 @@ the_transaction_t::callback_request()
   }
   
   // execute the status callback:
-  status_cb_(status_cb_data_, this, NULL);
+  status_cb_(status_cb_data_, this, nullptr);
   
   while (true)
   {

--- a/src/itkIRCommon.cxx
+++ b/src/itkIRCommon.cxx
@@ -180,7 +180,7 @@ load_transform(std::istream & si, const std::string & transform_type)
 
   itk::TransformBase::Pointer t = dynamic_cast<itk::TransformBase *>(tmp.GetPointer());
 
-  if (t.GetPointer() == NULL)
+  if (t.GetPointer() == nullptr)
   {
     cerr << "could not instantiate " << transform_type << ", giving up ..." << endl;
     return t;
@@ -714,13 +714,13 @@ find_inverse(const pnt2d_t &          tile_min, // tile space
              const unsigned int       pick_up_pace_steps)
 {
   // #define DEBUG_FIND_INVERSE
-  if (tile_to_mosaic == NULL)
+  if (tile_to_mosaic == nullptr)
   {
     return false;
   }
 
   const itk::GridTransform * gridTransform = dynamic_cast<const itk::GridTransform *>(tile_to_mosaic);
-  if (gridTransform != NULL)
+  if (gridTransform != nullptr)
   {
     // special case for the grid transform -- the inverse is either exact
     // or it doesn't exist (maps to extreme coordinates):
@@ -866,13 +866,13 @@ find_inverse(const base_transform_t * mosaic_to_tile,
              const unsigned int       pick_up_pace_steps)
 {
   // #define DEBUG_FIND_INVERSE
-  if (tile_to_mosaic == NULL)
+  if (tile_to_mosaic == nullptr)
   {
     return false;
   }
 
-  if (dynamic_cast<const itk::GridTransform *>(tile_to_mosaic) != NULL ||
-      dynamic_cast<const itk::MeshTransform *>(tile_to_mosaic) != NULL)
+  if (dynamic_cast<const itk::GridTransform *>(tile_to_mosaic) != nullptr ||
+      dynamic_cast<const itk::MeshTransform *>(tile_to_mosaic) != nullptr)
   {
     // special case for the grid transform -- the inverse is either exact
     // or it doesn't exist (maps to extreme coordinates):

--- a/src/itkIRText.cxx
+++ b/src/itkIRText.cxx
@@ -44,7 +44,7 @@
 // the_text_t::the_text_t
 // 
 the_text_t::the_text_t(const char * text):
-  text_(NULL),
+  text_(nullptr),
   size_(0)
 {
   assign(text);
@@ -54,7 +54,7 @@ the_text_t::the_text_t(const char * text):
 // the_text_t::the_text_t
 // 
 the_text_t::the_text_t(const char * text, const size_t & size):
-  text_(NULL),
+  text_(nullptr),
   size_(0)
 {
   assign(text, size);
@@ -64,7 +64,7 @@ the_text_t::the_text_t(const char * text, const size_t & size):
 // the_text_t::the_text_t
 // 
 the_text_t::the_text_t(const the_text_t & text):
-  text_(NULL),
+  text_(nullptr),
   size_(0)
 {
   assign(text.text_, text.size_);
@@ -74,7 +74,7 @@ the_text_t::the_text_t(const the_text_t & text):
 // the_text_t::the_text_t
 // 
 the_text_t::the_text_t(const std::list<char> & text):
-  text_(NULL),
+  text_(nullptr),
   size_(text.size())
 {
   text_ = new char [size_ + 1];
@@ -160,7 +160,7 @@ short int
 the_text_t::toShort(bool * ok, int base) const
 {
   long int num = toULong(ok, base);
-  if (ok != NULL) *ok &= ((num >= SHRT_MIN) && (num <= SHRT_MAX));
+  if (ok != nullptr) *ok &= ((num >= SHRT_MIN) && (num <= SHRT_MAX));
   return (short int)(num);
 }
 
@@ -171,7 +171,7 @@ unsigned short int
 the_text_t::toUShort(bool * ok, int base) const
 {
   unsigned long int num = toULong(ok, base);
-  if (ok != NULL) *ok &= (num <= USHRT_MAX);
+  if (ok != nullptr) *ok &= (num <= USHRT_MAX);
   return (unsigned short int)(num);
 }
 
@@ -182,7 +182,7 @@ int
 the_text_t::toInt(bool * ok, int base) const
 {
   long int num = toULong(ok, base);
-  if (ok != NULL) *ok &= ((num >= INT_MIN) && (num <= INT_MAX));
+  if (ok != nullptr) *ok &= ((num >= INT_MIN) && (num <= INT_MAX));
   return int(num);
 }
 
@@ -193,7 +193,7 @@ unsigned int
 the_text_t::toUInt(bool * ok, int base) const
 {
   unsigned long int num = toULong(ok, base);
-  if (ok != NULL) *ok &= (num <= UINT_MAX);
+  if (ok != nullptr) *ok &= (num <= UINT_MAX);
   return (unsigned int)(num);
 }
 
@@ -203,9 +203,9 @@ the_text_t::toUInt(bool * ok, int base) const
 long int
 the_text_t::toLong(bool * ok, int base) const
 {
-  char * endptr = NULL;
+  char * endptr = nullptr;
   long int num = strtol(text_, &endptr, base);
-  if (ok != NULL) *ok = !(text_ == endptr || errno == ERANGE);
+  if (ok != nullptr) *ok = !(text_ == endptr || errno == ERANGE);
   return num;
 }
 
@@ -215,9 +215,9 @@ the_text_t::toLong(bool * ok, int base) const
 unsigned long int
 the_text_t::toULong(bool * ok, int base) const
 {
-  char * endptr = NULL;
+  char * endptr = nullptr;
   unsigned long int num = strtoul(text_, &endptr, base);
-  if (ok != NULL) *ok = !(text_ == endptr || errno == ERANGE);
+  if (ok != nullptr) *ok = !(text_ == endptr || errno == ERANGE);
   return num;
 }
 
@@ -237,9 +237,9 @@ the_text_t::toFloat(bool * ok) const
 double
 the_text_t::toDouble(bool * ok) const
 {
-  char * endptr = NULL;
+  char * endptr = nullptr;
   double num = strtod(text_, &endptr);
-  if (ok != NULL) *ok = !(text_ == endptr || errno == ERANGE);
+  if (ok != nullptr) *ok = !(text_ == endptr || errno == ERANGE);
   return num;
 }
 

--- a/src/itkIRUtils.cxx
+++ b/src/itkIRUtils.cxx
@@ -112,7 +112,7 @@ namespace the
 			  0,	   // flags (precomposed, composite,... )
 			  utf8,    // source multi-byte character string
 			  -1,	   // number of bytes in the source string
-			  NULL,	   // wide-character destination
+			  nullptr,	   // wide-character destination
 			  0);	   // destination buffer size
     
     utf16 = new wchar_t[wcs_size + 1];
@@ -178,13 +178,13 @@ namespace the
   FILE *
   fopen_utf8(const char * filename_utf8, const char * mode)
   {
-    FILE * file = NULL;
+    FILE * file = nullptr;
     
 #ifdef _WIN32
-    wchar_t * filename_utf16 = NULL;
+    wchar_t * filename_utf16 = nullptr;
     utf8_to_utf16(filename_utf8, filename_utf16);
     
-    wchar_t * mode_utf16 = NULL;
+    wchar_t * mode_utf16 = nullptr;
     utf8_to_utf16(mode, mode_utf16);
     
     _wfopen_s(&file, filename_utf16, mode_utf16);
@@ -204,10 +204,10 @@ namespace the
   rename_utf8(const char * old_utf8, const char * new_utf8)
   {
 #ifdef _WIN32
-    wchar_t * old_utf16 = NULL;
+    wchar_t * old_utf16 = nullptr;
     utf8_to_utf16(old_utf8, old_utf16);
     
-    wchar_t * new_utf16 = NULL;
+    wchar_t * new_utf16 = nullptr;
     utf8_to_utf16(new_utf8, new_utf16);
     
     int ret = _wrename(old_utf16, new_utf16);
@@ -229,7 +229,7 @@ namespace the
   remove_utf8(const char * filename_utf8)
   {
 #ifdef _WIN32
-    wchar_t * filename_utf16 = NULL;
+    wchar_t * filename_utf16 = nullptr;
     utf8_to_utf16(filename_utf8, filename_utf16);
     
     int ret = _wremove(filename_utf16);
@@ -249,7 +249,7 @@ namespace the
   rmdir_utf8(const char * dir_utf8)
   {
 #ifdef _WIN32
-    wchar_t * dir_utf16 = NULL;
+    wchar_t * dir_utf16 = nullptr;
     utf8_to_utf16(dir_utf8, dir_utf16);
     
     int ret = _wrmdir(dir_utf16);
@@ -269,7 +269,7 @@ namespace the
   mkdir_utf8(const char * path_utf8)
   {
 #ifdef _WIN32
-    wchar_t * path_utf16 = NULL;
+    wchar_t * path_utf16 = nullptr;
     utf8_to_utf16(path_utf8, path_utf16);
     
     int ret = _wmkdir(path_utf16);

--- a/src/itkRBFTransform.cxx
+++ b/src/itkRBFTransform.cxx
@@ -148,7 +148,7 @@ RBFTransform::GetInverse() const
   tile_max[1] = GetYmax() * 2;
 
   RBFTransform::Pointer inverse = RBFTransform::New();
-  inverse->setup(tile_min, tile_max, num_pts, num_pts ? &(xy_vec[0]) : NULL, num_pts ? &(uv_vec[0]) : NULL);
+  inverse->setup(tile_min, tile_max, num_pts, num_pts ? &(xy_vec[0]) : nullptr, num_pts ? &(uv_vec[0]) : nullptr);
 
   return inverse.GetPointer();
 }

--- a/src/itkRegularStepGradientDescentOptimizer2.cxx
+++ b/src/itkRegularStepGradientDescentOptimizer2.cxx
@@ -69,7 +69,7 @@ RegularStepGradientDescentOptimizer2::RegularStepGradientDescentOptimizer2()
   , log_(cerr_log())
 {
   itkDebugMacro("Constructor");
-  m_CostFunction = NULL;
+  m_CostFunction = nullptr;
 }
 
 //----------------------------------------------------------------


### PR DESCRIPTION
This is not merely due to style. Sample error message:
```log
 /Users/svc-dashboard/D/ITKNornir/src/IRGridTransform.cxx
In file included from /Users/svc-dashboard/D/ITKNornir/src/IRGridTransform.cxx:35: In file included from /Users/svc-dashboard/D/ITKNornir/include/IRGridTransform.h:38: /Users/svc-dashboard/D/ITKNornir/include/itkIRCommon.h:2979:26: error: ambiguous conversion for functional-style cast from 'long' to 'typename msk_interpolator_t::Pointer' (aka 'SmartPointer<itk::NearestNeighborInterpolateImageFunction<itk::Image<unsigned char, 2>, double>>')
  msk.assign(num_images, typename msk_interpolator_t::Pointer(NULL));
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This makes it compile on `Apple clang version 15.0.0 (clang-1500.1.0.2.5)`, OS `Darwin Kernel Version 22.6.0: Mon Jun 24 01:25:37 PDT 2024; root:xnu-8796.141.3.706.2~1/RELEASE_X86_64 x86_64`